### PR TITLE
Remove usage of __version__ in docs

### DIFF
--- a/docs/intro/install.md
+++ b/docs/intro/install.md
@@ -73,8 +73,12 @@ or through importing as a library:
 
 ```pycon
 >>> import wpextract
->>> wpextract.__version__
-1.0.0
+>>> help(wpextract)
+Help on package wpextract:
+
+NAME
+    wpextract
+# etc...
 ```
 
 ## For Development


### PR DESCRIPTION
Hotfix to docs to change the install example to use `help()` instead of `__version__` since that attribute isn't set currently.

Will implement `__version__` on dev and go back to using it here.