### PR TITLE
Add ref to langcodes docs

### DIFF
--- a/docs/advanced/multilingual.md
+++ b/docs/advanced/multilingual.md
@@ -1,6 +1,6 @@
 # Multilingual Sites
 
-If sites publish in multiple languages and use a plugin to present a list of language versions, wpextract can parse this and add multilingual data in the output dataset.
+If sites publish in multiple languages and use a plugin to present a list of language versions, wpextract can parse this and add links between translated versions in the output dataset.
 
 ## Extraction Process
 

--- a/docs/intro/start.md
+++ b/docs/intro/start.md
@@ -25,9 +25,7 @@ $ pipx install wpextract
 WPextract works in two steps:
 
 1. The **downloader** uses the WordPress REST API to obtain all content on the site, which is stored as a single, long file
-2. The **extractor** converts this into a usable dataset by enriching the downloaded content. This includes extracting text, images, resolving links to posts/pages, and finding translated versions[^lang]
-
-[^lang]: {-} See the specific guide for more on multilingual extraction.
+2. The **extractor** converts this into a usable dataset by enriching the downloaded content. This includes extracting text, images, resolving links to posts/pages, and finding translated versions ([more on translation extraction](../advanced/multilingual.md))
 
 We call these two stages using two CLI commands ([`wpextract download`](../usage/download.md#command-usage) and [`wpextract extract`](../usage/extract.md#command-usage)). Alternatively, WPExtract can be integrated into a project by [using it as a library](../advanced/library.md).
 

--- a/src/wpextract/parse/translations/_resolver.py
+++ b/src/wpextract/parse/translations/_resolver.py
@@ -14,5 +14,9 @@ class TranslationLink(ResolvableLink):
 
     @property
     def language(self) -> Language:
-        """Parsed and normalized language. Populated automatically post-init."""
+        """Parsed and normalized language. Populated automatically post-init.
+
+        See Also:
+            [`langcodes` documentation](https://github.com/georgkrause/langcodes?tab=readme-ov-file#language-objects)
+        """
         return Language.get(self.lang, normalize=True)


### PR DESCRIPTION
Langcodes doesn't have docs with an inventory to cross-reference, so add a manual link.

Also fix a broken footnote I noticed.