### PR TITLE
Improve content text extraction

### DIFF
--- a/src/wpextract/parse/content.py
+++ b/src/wpextract/parse/content.py
@@ -10,7 +10,7 @@ from wpextract.extractors.data.links import Link, ResolvableLink
 from wpextract.extractors.media import get_caption
 from wpextract.util.str import squash_whitespace
 
-EXCLUDED_CONTENT_TAGS = {"figcaption"}
+EXCLUDED_CONTENT_TAGS = {"figcaption", "table"}
 NEWLINE_TAGS = {"br", "p"}
 
 
@@ -136,7 +136,7 @@ def extract_content_data(doc: BeautifulSoup, self_link: str) -> pd.Series:
     """Extract the links, embeds, images and text content of the document.
 
     Args:
-        doc: A parsed document.
+        doc: A parsed document body.
         self_link: The URL of the page.
 
     Returns:
@@ -147,12 +147,12 @@ def extract_content_data(doc: BeautifulSoup, self_link: str) -> pd.Series:
     images = extract_images(doc, self_link)
 
     doc_c = copy.copy(doc)
-    for child in doc_c.descendants:
-        if type(child) == NavigableString:
+    for child in list(doc_c.descendants):
+        if child.decomposed or type(child) == NavigableString:
             continue
 
         if child.name in EXCLUDED_CONTENT_TAGS:
-            child.extract()
+            child.decompose()
 
     content_text = squash_whitespace(_get_text(doc_c))
 

--- a/tests/parse/test_content.py
+++ b/tests/parse/test_content.py
@@ -82,7 +82,6 @@ def test_extract_image_without_src(datadir: Path):
 
 def test_extract_content(datadir: Path):
     doc = BeautifulSoup((datadir / "content_extraction.html").read_text(), "lxml")
-
     content_series = extract_content_data(doc, "https://example.org/home")
     text = content_series[0]
 

--- a/tests/parse/test_content/content_extraction.html
+++ b/tests/parse/test_content/content_extraction.html
@@ -1,8 +1,18 @@
+<!-- Note: this isn't a complete HTML doc because it's designed to run on just the content -->
 <p>The first paragraph.</p>
 <figure>
   <img src="/example-image.png" alt="Some alt text" />
   <figcaption>A caption</figcaption>
 </figure>
+<figure>
+  <img src="/example-image.png" alt="Some alt text" />
+  <figcaption>A second caption</figcaption>
+</figure>
+<table>
+  <tr>
+    <td>This is inside a table cell</td>
+  </tr>
+</table>
 <!-- a comment, I should be ignored -->
 <p>The second paragraph.</p><p>The third paragraph.</p>
 Not in a paragraph.


### PR DESCRIPTION
- Fix bug where only the first element to be excluded from post content was removed
  - Changed to use `el.decompose()` instead of `el.extract()` because this more robustly destroys the element
- Add tables to the list of elements which should be excluded when extracting post content
- Improve the test to cover these changes